### PR TITLE
fix(ci): fix conda publish workflow failing on git checkout

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,32 +1,31 @@
+{% set version = environ.get('PYMETEO_VERSION', '0.0.0') %}
+
 package:
   name: pymeteo
-  version: "1.1.0"
+  version: "{{ version }}"
 
 build:
   noarch: python
   number: 0
-  script: python setup.py install
+  script: python -m pip install --no-deps --no-build-isolation ..
 
 source:
-  git_url: https://github.com/cwebster2/pyMeteo.git
-  git_rev: "1.1.0"
-  git_depth: 1
+  path: ..
 
 requirements:
-  build:
-    - python
-    - setuptools
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68.0
 
   run:
-    - python
-    - pyqt
-    - numpy
-    - matplotlib
-    - hdf5
+    - python >=3.10
+    - numpy >=1.23
+    - matplotlib >=3.5
 
 about:
   home: https://github.com/cwebster2/pyMeteo
-  license: BSD3
+  license: BSD-3-Clause
   license_file: LICENSE
   summary: General meteorological routines, skew-T/log-p plotting and working with CM1 model data.
 

--- a/.github/workflows/publish-conda.yml
+++ b/.github/workflows/publish-conda.yml
@@ -25,9 +25,8 @@ jobs:
       - name: Build
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          PYMETEO_VERSION: ${{ github.event.release.tag_name || '0.0.0' }}
         run: |
-          cd .conda
-          conda install conda-build conda-index
+          conda install conda-build
           conda config --set anaconda_upload yes
-          conda-build --token $ANACONDA_TOKEN --output-folder . .
-          conda-index .
+          conda-build --token $ANACONDA_TOKEN .conda


### PR DESCRIPTION
## Summary

Fix the `publish-conda` workflow which fails because `conda-build` cannot checkout the release tag from a shallow git clone.

- Replace git source with local path source so conda-build uses the already-checked-out code
- Make package version dynamic via `PYMETEO_VERSION` env var from release tag name
- Fix build script (`setup.py` no longer exists, now uses `pip install`)
- Align conda run dependencies with `pyproject.toml`

## Rationale

The workflow was broken by three compounding issues:

1. **Shallow clone + tag checkout**: `conda-build` did `git clone --depth 1` then `git checkout 1.1.0`, which fails because the tag isn't reachable in a depth-1 clone
2. **Stale build script**: `meta.yaml` referenced `python setup.py install` but the project migrated to `pyproject.toml` (no `setup.py` exists)
3. **Hardcoded version**: version `1.1.0` was hardcoded in `meta.yaml`, requiring manual updates on every release

The fix eliminates all three problems by using `source: path: ..` (the code is already checked out by `actions/checkout`), a Jinja2 env var for the version, and `pip install` for the build.

## Changes

- `.conda/meta.yaml`: Remove `git_url`/`git_rev`/`git_depth`, use `path: ..` source, dynamic version via `environ.get('PYMETEO_VERSION')`, `pip install` build script, updated deps
- `.github/workflows/publish-conda.yml`: Pass `PYMETEO_VERSION` from release tag, run `conda-build .conda` from repo root, remove unused `conda-index`

## Testing

- [ ] Trigger workflow via `workflow_dispatch` or a test release