### PR TITLE
fix(ci): read conda version from VERSION file and fix pip install path

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = environ.get('PYMETEO_VERSION', '0.0.0') %}
+{% set version_match = load_file_regex(load_file='VERSION', regex_pattern='(.+)') %}
+{% set version = version_match[1].strip() %}
 
 package:
   name: pymeteo
@@ -7,7 +8,7 @@ package:
 build:
   noarch: python
   number: 0
-  script: python -m pip install --no-deps --no-build-isolation ..
+  script: python -m pip install --no-deps --no-build-isolation .
 
 source:
   path: ..

--- a/.github/workflows/publish-conda.yml
+++ b/.github/workflows/publish-conda.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Build
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          PYMETEO_VERSION: ${{ github.event.release.tag_name || '0.0.0' }}
         run: |
           conda install conda-build
           conda config --set anaconda_upload yes


### PR DESCRIPTION
## Summary

Fix the conda build workflow so it reads the version from the `VERSION` file instead of requiring a GitHub release tag, and fix the pip install path in `meta.yaml`.

- Read version from `VERSION` file using `load_file_regex` instead of `PYMETEO_VERSION` env var
- Fix pip install path from `..` to `.` (source is already copied into `SRC_DIR`)
- Remove unused `PYMETEO_VERSION` env var from workflow

## Rationale

The conda workflow previously required a GitHub release event to set `PYMETEO_VERSION` from the release tag. Running via `workflow_dispatch` would fall back to `0.0.0`. Now the version is single-sourced from the `VERSION` file, consistent with how `pyproject.toml` reads it, and the workflow can be triggered manually with the correct version.

The pip install path `..` was also incorrect — `conda-build` copies the project root into `SRC_DIR` via the `source: path: ..` directive, so the install command runs from within the source tree and should use `.`.

## Changes

- `.conda/meta.yaml`: Replace `environ.get('PYMETEO_VERSION')` with `load_file_regex` reading `VERSION` file; fix pip install path from `..` to `.`
- `.github/workflows/publish-conda.yml`: Remove `PYMETEO_VERSION` env var

## Testing

- [ ] Trigger conda build workflow via `workflow_dispatch` and verify it picks up the version from `VERSION`