### PR TITLE
fix(ci): resolve conda-build crash with Python 3.13

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,5 +1,4 @@
-{% set version_match = load_file_regex(load_file='VERSION', regex_pattern='(.+)') %}
-{% set version = version_match[1].strip() %}
+{% set version = environ.get('PACKAGE_VERSION', '0.0.0') %}
 
 package:
   name: pymeteo

--- a/.github/workflows/publish-conda.yml
+++ b/.github/workflows/publish-conda.yml
@@ -25,7 +25,11 @@ jobs:
       - name: Build
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          PACKAGE_VERSION: ${{ github.event.release.tag_name || '' }}
         run: |
+          if [ -z "$PACKAGE_VERSION" ]; then
+            export PACKAGE_VERSION=$(cat VERSION | tr -d '[:space:]')
+          fi
           conda install conda-build
           conda config --set anaconda_upload yes
           conda-build --token $ANACONDA_TOKEN .conda


### PR DESCRIPTION
## Summary

Fix conda-build failing during metadata rendering on Python 3.13 with `TypeError: unsupported operand type(s) for +: 'int' and 'str'`.

- Replace `load_file_regex` in `.conda/meta.yaml` with `environ.get('PACKAGE_VERSION')`
- Set `PACKAGE_VERSION` env var in the publish workflow from the release tag or `VERSION` file

## Rationale

The `load_file_regex` Jinja2 helper in conda-build has a bug under Python 3.13: the `UndefinedNeverFail` proxy class crashes when chaining item access (`[1]`) with attribute access (`.strip()`) because `_undefined_name` is stored as an `int` rather than a `str`. During the first metadata parse pass with `permit_undefined_jinja=True`, the VERSION file isn't available yet (source not extracted), so `load_file_regex` returns a value that gets wrapped in `UndefinedNeverFail`, triggering the crash.

Using `environ.get()` completely sidesteps the buggy code path and is more explicit about where the version comes from.

## Changes

- `.conda/meta.yaml`: Replace `load_file_regex`/`version_match[1].strip()` with `environ.get('PACKAGE_VERSION', '0.0.0')`
- `.github/workflows/publish-conda.yml`: Set `PACKAGE_VERSION` from the release tag name (for release triggers) or by reading the `VERSION` file (for `workflow_dispatch`)

## Breaking Changes

None

## Testing

- [x] Validated Jinja2 template renders correctly with the env var set
- [x] Verified shell fallback reads VERSION file properly
- [ ] Full conda-build test requires conda environment (not available locally)