### PR TITLE
fix(ci): use env var for anaconda token instead of CLI arg

### DIFF
--- a/.github/workflows/publish-conda.yml
+++ b/.github/workflows/publish-conda.yml
@@ -24,7 +24,7 @@ jobs:
           conda-channels: anaconda, conda-forge, cwebster2
       - name: Build
         env:
-          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
           PACKAGE_VERSION: ${{ github.event.release.tag_name || '' }}
         run: |
           if [ -z "$PACKAGE_VERSION" ]; then
@@ -32,4 +32,4 @@ jobs:
           fi
           conda install conda-build anaconda-client
           conda config --set anaconda_upload yes
-          conda-build --token $ANACONDA_TOKEN .conda
+          conda-build .conda


### PR DESCRIPTION
## Summary

Fix the conda publish workflow failing with `anaconda: error: argument -t/--token: invalid file_or_token value`.

- Replace `--token $ANACONDA_TOKEN` CLI argument with `ANACONDA_API_TOKEN` environment variable
- Remove the now-unnecessary `ANACONDA_TOKEN` env var

## Rationale

Newer versions of `anaconda-client` have stricter validation on the `-t`/`--token` CLI argument, rejecting the token value. Using the `ANACONDA_API_TOKEN` environment variable is the recommended approach — it is recognized automatically by both `anaconda-client` and `conda-build` (when `anaconda_upload` is enabled), bypasses CLI argument validation entirely, and is more secure since the token never appears in the process argument list.

## Changes

- `.github/workflows/publish-conda.yml`: Replaced `ANACONDA_TOKEN` env var with `ANACONDA_API_TOKEN`, removed `--token` flag from `conda-build` command

## Breaking Changes

None

## Testing

- [ ] Trigger the publish-conda workflow manually to verify the upload succeeds